### PR TITLE
Add sparql query for CQ004

### DIFF
--- a/competency_questions/CQ004.sparql
+++ b/competency_questions/CQ004.sparql
@@ -1,0 +1,13 @@
+PREFIX wb: <http://hercules-demo.wiki.opencura.com/entity/>
+PREFIX wbt: <http://hercules-demo.wiki.opencura.com/prop/direct/>
+
+SELECT ?centreLabel (COUNT(?seal) AS ?numberOfSeals) WHERE {
+  ?centre wbt:P1 wb:Q2 ; # get entities of type ResearchInstitute
+          wbt:P2 ?seal . # with property hasSealOfQuality
+  SERVICE wikibase:label {
+    bd:serviceParam wikibase:language "es" .
+  }
+}
+GROUP BY ?centreLabel
+ORDER BY DESC(?numberOfSeals)
+LIMIT 10


### PR DESCRIPTION
CQ004 #16: "Como usuario requiero obtener el Top 10 (o el número que se considere relevante pues será parametrizable) de centros/estructuras de investigación que posean sellos de calidad asociados, por ejemplo: el sello Severo Ochoa."

Query:
```sparql
PREFIX wb: <http://hercules-demo.wiki.opencura.com/entity/>
PREFIX wbt: <http://hercules-demo.wiki.opencura.com/prop/direct/>

SELECT ?centreLabel (COUNT(?seal) AS ?numberOfSeals) WHERE {
  ?centre wbt:P1 wb:Q2 ; # get entities of type ResearchInstitute
          wbt:P2 ?seal . # with property hasSealOfQuality
  SERVICE wikibase:label {
    bd:serviceParam wikibase:language "es" .
  }
}
GROUP BY ?centreLabel
ORDER BY DESC(?numberOfSeals)
LIMIT 10
```

<br>

Link to execute: https://tinyurl.com/st6zmg7

The main problem with this query is that we are not getting a "TOP 10", we are just ordering the centres based on their number of seals. I don't know which criteria to follow when making the TOP 10, or if just ordering them based on the number of seals is ok.