### PR TITLE
Add sparql query for CQ009

### DIFF
--- a/competency_questions/CQ009.sparql
+++ b/competency_questions/CQ009.sparql
@@ -1,0 +1,15 @@
+PREFIX wb: <http://hercules-demo.wiki.opencura.com/entity/>
+PREFIX wbt: <http://hercules-demo.wiki.opencura.com/prop/direct/>
+
+SELECT ?patentLabel ?patentDescription WHERE {
+  ?centre wbt:P1 wb:Q2 ; # get entities of type ResearchInstitute
+          wbt:P6 ?patent ; # with property hasPatent
+          rdfs:label ?centreLabel .
+  ?patent schema:description ?patentDescription .
+  FILTER(str(?centreLabel) = "Dairy Research Institute of Asturias" && # centre to be parameterized
+         lang(?patentDescription) = "[AUTO_LANGUAGE]")                 # get description in our default language
+  SERVICE wikibase:label {
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es" .
+  }
+}
+ORDER BY DESC(?patentLabel)


### PR DESCRIPTION
CQ009 #14: Como usuario requiero obtener un listado de patentes, diseños industriales, etc. de un centro/estructura de investigación en un área/disciplina.

Proposed query:
```sparql
PREFIX wb: <http://hercules-demo.wiki.opencura.com/entity/>
PREFIX wbt: <http://hercules-demo.wiki.opencura.com/prop/direct/>

SELECT ?patentLabel ?patentDescription WHERE {
  ?centre wbt:P1 wb:Q2 ; # get entities of type ResearchInstitute
          wbt:P6 ?patent ; # with property hasPatent
          rdfs:label ?centreLabel .
  ?patent schema:description ?patentDescription .
  FILTER(str(?centreLabel) = "Dairy Research Institute of Asturias" && # centre to be parameterized
         lang(?patentDescription) = "[AUTO_LANGUAGE]")                 # get description in our default language
  SERVICE wikibase:label {
    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es" .
  }
}
ORDER BY DESC(?patentLabel)
```

<br>

Link to execute: https://tinyurl.com/sph76pz

<br>

The only problem that I see with this query is that we are not taking into account industrial designs, just patents. Maybe we should create an issue to add industrial designs to the ontology?