### PR TITLE
[WIP] Add sparql query for CQ025

### DIFF
--- a/competency_questions/CQ025.sparql
+++ b/competency_questions/CQ025.sparql
@@ -1,0 +1,16 @@
+#defaultView:Timeline
+PREFIX wb: <http://hercules-demo.wiki.opencura.com/entity/>
+PREFIX wbt: <http://hercules-demo.wiki.opencura.com/prop/direct/>
+
+SELECT ?phdThesesLabel ?authorLabel (year(?publicationDate) as ?publicationYear) ?publicationDate WHERE {
+  ?phdTheses wbt:P1 wb:Q74 ;       # get entities of type PhdThesis
+             wbt:P15 ?supervisor ;
+             wbt:P10 ?author .
+  OPTIONAL { ?phdTheses wbt:P14 ?publicationDate . }
+  ?supervisor rdfs:label ?supervisorLabel .
+  FILTER(?supervisorLabel = "José Emilio Labra Gayo"@es) # supervised by José Emilio Labra Gayo
+  SERVICE wikibase:label {
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es" .
+  }
+}
+ORDER BY ASC(?phdThesesLabel)


### PR DESCRIPTION
## Introduction
CQ025 #40: Obtener el listado de los trabajos que he dirigido/codirigido ya sean de grado (TFG), máster (TFM), o tesis doctorales.

## Proposed query
```sparql
#defaultView:Timeline
PREFIX wb: <http://hercules-demo.wiki.opencura.com/entity/>
PREFIX wbt: <http://hercules-demo.wiki.opencura.com/prop/direct/>

SELECT ?phdThesesLabel ?authorLabel (year(?publicationDate) as ?publicationYear) ?publicationDate WHERE {
  ?phdTheses wbt:P1 wb:Q74 ;       # get entities of type PhdThesis
             wbt:P15 ?supervisor ;
             wbt:P10 ?author .
  OPTIONAL { ?phdTheses wbt:P14 ?publicationDate . }
  ?supervisor rdfs:label ?supervisorLabel .
  FILTER(?supervisorLabel = "José Emilio Labra Gayo"@es) # supervised by José Emilio Labra Gayo
  SERVICE wikibase:label {
    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es" .
  }
}
ORDER BY ASC(?phdThesesLabel)
```

<br>

## Link to execute
https://tinyurl.com/syjpgx5

## Additional comments
We still need to add TFGs and TFMs to the ontology and to the query before we can close this pull request. For the moment we are taking into account just PHD Theses