### PR TITLE
Update sparql query for CQ029

### DIFF
--- a/doc/competency_questions/CQ029.sparql
+++ b/doc/competency_questions/CQ029.sparql
@@ -2,13 +2,13 @@ PREFIX wb: <http://hercules-demo.wiki.opencura.com/entity/>
 PREFIX wbt: <http://hercules-demo.wiki.opencura.com/prop/direct/>
 
 SELECT DISTINCT ?publicationLabel ?publisherLabel (year(?publicationDate) as ?publicationYear) WHERE {
-  ?author wbt:P1 wb:Q44 ;                # get entities of type Teaching and research personnel
+  ?author wbt:P1 wb:Q1 ;                 # get entities of type NamedIndividual
           wbt:P11 ?publication .         # with publications
-  ?publication wbt:P1 ?publicationType ;
-               wbt:P14 ?publicationDate ;
-               wbt:P9 ?publisher .
+  ?publication wbt:P1 ?publicationType .
   ?publicationType (wbt:P4)* wb:Q47 .    # publications that are subclasses of Publication (Q47)
   ?author rdfs:label ?authorLabel .
+  OPTIONAL { ?publication wbt:P14 ?publicationDate . }
+  OPTIONAL { ?publication wbt:P9 ?publisher . }
   FILTER(?authorLabel = "Paco Calvo"@es) # authored by Paco Calvo
   SERVICE wikibase:label {
     bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es" .


### PR DESCRIPTION
Closes #98.

There is longer no need to specify that the person must have role "Researching" or "Teaching", since a person can have Publications independently of their role.

There is also a fix with the SPARQL query where previously if one of the optional predicates of the publication was not found neither of the values inside the OPTIONAL construct was shown. Now we have separate OPTIONALs so if one of the predicates is not found, the other values can still appear in the result if present.