### PR TITLE
[HOP-0130] Ontology versioning

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -2,7 +2,7 @@ name: Build and Deploy Documentation
 
 on:
   push:
-    branches: 
+    branches:
       - 'gh-pages'
   page_build:
 
@@ -29,6 +29,23 @@ jobs:
 
     - name: Remove gitignore
       run: rm .gitignore
+
+    - name: Get current time
+      uses: 1466587594/get-current-time@v1
+      id: current-time
+      with:
+        format: YYYY-MM-DD
+        utcOffset: "+08:00"
+
+    - name: Store version using current date
+      env:
+        F_TIME: "${{ steps.current-time.outputs.formattedTime }}"
+      run: |
+        git checkout gh-pages
+        cp -an current/. build/current/
+        cd build
+        mkdir $F_TIME
+        cp -a current/. $F_TIME/
 
     - name: Deploy
       uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/build_ontology.yml
+++ b/.github/workflows/build_ontology.yml
@@ -1,8 +1,8 @@
 name: Build and Deploy Ontology
 
 on:
-  push:
-    branches: [ master ]
+  release:
+     types: [ published ]
 
 jobs:
   build-ontology:
@@ -22,7 +22,7 @@ jobs:
 
     - name: Remove gitignore
       run: rm .gitignore
-    
+
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       with:

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -4,7 +4,7 @@ import requests
 from common import OUTPUT_FOLDER, try_create_dir
 
 LODE_ENDPOINT = 'http://150.146.207.114/lode/extract'
-ONTOLOGY_URL = 'http://www.weso.es/hercules-ontology/asio.xml'
+ONTOLOGY_URL = 'http://www.weso.es/hercules-ontology/current/asio.xml'
 OUTPUT_FILE_NAME = 'asio.html'
 
 def extract_docs_from(onto_url, lode_endpoint):

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -1,6 +1,6 @@
 import os
 
-OUTPUT_FOLDER = 'build'
+OUTPUT_FOLDER = os.path.join('build', 'current')
 
 def try_create_dir(dir_name):
     if not os.path.exists(dir_name):


### PR DESCRIPTION
Closes #84.

The following changes have been made:
* The ontology is now published when a new GitHub release is made, not with every new push to master.
* The current date is used to store the different versions in GitHub pages. Last version will be stored under the 'current' directory, and other versions will be stored in separate directories with the date of their release (YYYY-MM-DD format).