### PR TITLE
[HOP-0156] Add sparql queries for CQ019

### DIFF
--- a/doc/competency_questions/CQ019.sparql
+++ b/doc/competency_questions/CQ019.sparql
@@ -1,0 +1,20 @@
+#defaultView:Timeline
+PREFIX p: <http://hercules-demo.wiki.opencura.com/prop/>
+PREFIX pq: <http://hercules-demo.wiki.opencura.com/prop/qualifier/>
+PREFIX ps: <http://hercules-demo.wiki.opencura.com/prop/statement/>
+PREFIX wb: <http://hercules-demo.wiki.opencura.com/entity/>
+PREFIX wbt: <http://hercules-demo.wiki.opencura.com/prop/direct/>
+
+SELECT DISTINCT ?researcherLabel ?numberOfCitations ?date WHERE {
+  ?researcher wbt:P17 wb:Q44 . # get entities of role Researching
+  ?researcher rdfs:label ?researcherLabel .
+  FILTER(?researcherLabel = "José Emilio Labra Gayo"@es) # researcher to be parametrized
+  ?researcher p:P39 [
+    ps:P39 ?numberOfCitations ;
+    pq:P44 ?date
+  ] .
+  SERVICE wikibase:label {
+    bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en,es" .
+  }
+}
+ORDER BY ?date

--- a/doc/competency_questions/README.md
+++ b/doc/competency_questions/README.md
@@ -36,6 +36,9 @@ https://tinyurl.com/y7qlopbe
 ## CQ018
 https://tinyurl.com/y7dpqwg9
 
+## CQ019
+Same as CQ018: https://tinyurl.com/y7dpqwg9
+
 ## CQ020
 * version A (default subject area): https://tinyurl.com/y8hw5ka4
 * version B (level 1 subject areas): https://tinyurl.com/yc6u4kk4


### PR DESCRIPTION
Closes #34 

As discussed in the issue thread, that competency question can't be completely answered by the ontology since we would need a system capable of predicting the evolution of data.

However, to solve this issue we are going to return the evolution of each indicator in a given timeframe. This shows that the ontology is capable of returning the data necessary to then create a prediction system that returns the wanted results.

This query is the same as the one created for #154 